### PR TITLE
Update populate_rcnotes_in_log_task.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ doc/auto_examples/
 
 *.csv
 *.out
+
+.db.secrets.txt

--- a/examples/dotdb.secrets.txt
+++ b/examples/dotdb.secrets.txt
@@ -1,0 +1,5 @@
+[neurobooth.terra.db]
+DB_name = my_neurobooth
+User = db_user_name
+Password = db_pwd
+Host = localhost

--- a/examples/plot_postgres.py
+++ b/examples/plot_postgres.py
@@ -35,11 +35,12 @@ from neurobooth_terra import list_tables, create_table, drop_table, Table
 
 import psycopg2
 import pandas as pd
-
+import scripts.credential_reader as reader
 # %%
 # Then, we will create a connection using ``psycopg2``.
-connect_str = ("dbname='neurobooth' user='neuroboother' host='localhost' "
-               "password='neuroboothrocks'")
+db_args = reader.read_db_secrets()
+connect_str = (f"dbname={db_args['database']} user={db_args['user']}  host={db_args['host']} "
+               f"password={db_args['password']} ")
 
 conn = psycopg2.connect(connect_str)
 

--- a/neurobooth_terra/tests/test_dataflow.py
+++ b/neurobooth_terra/tests/test_dataflow.py
@@ -7,9 +7,9 @@ import psycopg2
 
 from neurobooth_terra import create_table, drop_table, Table
 from neurobooth_terra.dataflow import write_files, copy_files, delete_files
+import scripts.credential_reader as reader
 
-db_args = dict(database='neurobooth', user='neuroboother',
-               password='neuroboothrocks')
+db_args = reader.read_db_secrets()
 
 
 @pytest.fixture(scope="session")

--- a/neurobooth_terra/tests/test_postgres.py
+++ b/neurobooth_terra/tests/test_postgres.py
@@ -7,9 +7,12 @@ from numpy.testing import assert_raises
 
 from neurobooth_terra import Table, create_table, drop_table, query, list_tables
 from neurobooth_terra.postgres import execute
+import scripts.credential_reader as reader
 
-connect_str = ("dbname='neurobooth' user='neuroboother' host='localhost' "
-                "password='neuroboothrocks'")
+db_args = reader.read_db_secrets()
+connect_str = (f"dbname={db_args['database']} user={db_args['user']} host={db_args['host']} "
+               f"password={db_args['password']} ")
+
 
 def test_psql_connection():
     """Test that we can connect to the database"""

--- a/neurobooth_terra/tests/test_redcap.py
+++ b/neurobooth_terra/tests/test_redcap.py
@@ -10,10 +10,11 @@ from neurobooth_terra import create_table
 from neurobooth_terra.postgres import drop_table
 from neurobooth_terra.redcap import (iter_interval, extract_field_annotation,
                                      map_dtypes, rename_subject_ids)
+import scripts.credential_reader as reader
 
-connect_str = ("dbname='neurobooth' user='neuroboother' host='localhost' "
-               "password='neuroboothrocks'")
-
+db_args = reader.read_db_secrets()
+connect_str = (f"dbname={db_args['database']} user={db_args['user']} host={db_args['host']} "
+               f"password={db_args['password']} ")
 
 def _keyboard_interrupt(signal):
     while True:
@@ -24,6 +25,7 @@ def _keyboard_interrupt(signal):
 
 def test_iter_interval():
     """Test iter_interval."""
+
     times = list()
     wait = 2.
     process_time = 0.2

--- a/scripts/add_session_prefix_to_log_sensor_file.py
+++ b/scripts/add_session_prefix_to_log_sensor_file.py
@@ -4,6 +4,7 @@ Edit the log_sensor_file table to preprend missing session folder prefixes to fi
 
 import psycopg2
 import re
+import credential_reader as reader
 
 from sshtunnel import SSHTunnelForwarder
 from neurobooth_terra import Table
@@ -18,10 +19,7 @@ ssh_args = dict(
         allow_agent=False
 )
 
-# TODO: Keeping these details as it's currently elsewhere in the codebase, but needs to be stripped and changed!!!
-db_args = dict(
-    database='neurobooth', user='neuroboother', password='neuroboothrocks',
-)
+db_args = reader.read_db_secrets()
 
 table_id = 'log_sensor_file'
 where = f"file_start_time >= '2024-07-01' and file_end_time < '2024-07-03'"

--- a/scripts/add_session_prefix_trailing_slash_to_log_file.py
+++ b/scripts/add_session_prefix_trailing_slash_to_log_file.py
@@ -8,7 +8,7 @@ import psycopg2
 
 from sshtunnel import SSHTunnelForwarder
 from neurobooth_terra import Table
-
+import credential_reader as reader
 import os
 
 ssh_args = dict(
@@ -21,9 +21,7 @@ ssh_args = dict(
         allow_agent=False
 )
 
-db_args = dict(
-    database='neurobooth', user='neuroboother', password='neuroboothrocks',
-)
+db_args = reader.read_db_secrets()
 
 table_id = 'log_file'
 

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -1,6 +1,7 @@
 """The SSH arguments and connection arguments."""
 import os
 from redcap import Project
+import credential_reader as reader
 
 ssh_args = dict(
         ssh_address_or_host='neurodoor.nmr.mgh.harvard.edu',
@@ -11,9 +12,7 @@ ssh_args = dict(
         local_bind_address=('localhost', 6543)
 )
 
-db_args = dict(
-    database='neurobooth', user='neuroboother', password='neuroboothrocks'
-)
+db_args = reader.read_db_secrets()
 
 URL = 'https://redcap.partners.org/redcap/api/'
 API_KEY = os.environ.get('NEUROBOOTH_REDCAP_TOKEN')

--- a/scripts/credential_reader.py
+++ b/scripts/credential_reader.py
@@ -1,0 +1,26 @@
+import configparser as cp
+import os
+
+
+def read_db_secrets(db_secrets_file='.db.secrets.txt'):
+
+    """
+    Returns a dictionary of database credentials with keys:
+    'database' for the name of the postgres database
+    'user' for the pg username
+    'password' for the pg user password
+
+    The credential file is assumed to be in this folder. If it is not, replace the default argument
+    or override the default in the calling script
+
+    """
+
+    path = os.path.join(os.path.dirname(__file__), db_secrets_file)
+    config = cp.ConfigParser()
+    config.read(path)
+    db_creds = config['neurobooth.terra.db']
+    credentials = {'database': db_creds['DB_Name'],
+                   'user': db_creds['User'],
+                   'password': db_creds['Password'],
+                   'host': db_creds['Host']}
+    return credentials

--- a/scripts/dbdesigner_export.py
+++ b/scripts/dbdesigner_export.py
@@ -9,13 +9,15 @@ This example demonstrates how to create postgres table with neurobooth-terra.
 from neurobooth_terra import drop_table
 import psycopg2
 from neurobooth_terra import execute, drop_table
+import credential_reader as reader
 
 # drop all tables
 
 ###############################################################################
 # First, we will create a connection using ``psycopg2``.
-connect_str = ("dbname='neurobooth' user='neuroboother' host='localhost' "
-               "password='neuroboothrocks'")
+db_args = reader.read_db_secrets()
+connect_str = (f"dbname={db_args['database']} user={db_args['user']}  host={db_args['host']} "
+               f"password={db_args['password']} ")
 
 conn = psycopg2.connect(connect_str)
 

--- a/scripts/er_diagram.py
+++ b/scripts/er_diagram.py
@@ -9,10 +9,12 @@ import pygraphviz as pgv
 
 from neurobooth_terra import Table
 import psycopg2
+import credential_reader as reader
 
-#### Initialize connection to database
-connect_str = ("dbname='neurobooth' user='neuroboother' host='localhost' "
-               "password='neuroboothrocks'")
+# Initialize connection to database
+db_args = reader.read_db_secrets()
+connect_str = (f"dbname={db_args['database']} user={db_args['user']}  host={db_args['host']} "
+               f"password={db_args['password']} ")
 
 conn = psycopg2.connect(connect_str)
 

--- a/scripts/populate_rcnotes_in_log_task.py
+++ b/scripts/populate_rcnotes_in_log_task.py
@@ -7,6 +7,7 @@
 # 'Nones' into specific column in a table
 
 import os.path as op
+from typing import Dict
 
 import pandas as pd
 
@@ -15,67 +16,80 @@ import psycopg2
 from sshtunnel import SSHTunnelForwarder
 from neurobooth_terra import Table
 
-ssh_args = dict(
-        ssh_address_or_host='neurodoor.nmr.mgh.harvard.edu',
-        ssh_username='sp1022',
-        ssh_pkey='~/.ssh/id_rsa',
-        remote_bind_address=('192.168.100.1', 5432),
-        local_bind_address=('localhost', 6543),
-        allow_agent=False
-)
 
-db_args = dict(
-    database='neurobooth', user='neuroboother', password='neuroboothrocks',
-)
+def main(db_name: str, db_user: str, db_password) -> None:
+    """
+    Populates RC notes in log_task table
+    :param db_name str  The name of the database
+    :param db_user str  The database username
+    :param db_password  The database user's password
 
-data_dir = '/autofs/nas/neurobooth/data/'
+    :returns: None
 
-with SSHTunnelForwarder(**ssh_args) as tunnel:
-    with psycopg2.connect(port=tunnel.local_bind_port,
-                          host=tunnel.local_bind_host, **db_args) as conn:
-        # build table dataframes
-        table_log_task = Table('log_task', conn)
-        table_task = Table('nb_task', conn)
-        
-        log_task_df = table_log_task.query()
-        log_task_df.reset_index(inplace=True)
-        
-        task_df = table_task.query()
-        task_df.reset_index(inplace=True)
-        
-        # merging tables to get task spellings that are used for notes filenames
-        table_joined_df = pd.merge(log_task_df, task_df, on=['task_id'], how='left')
-        # for each row in table
-        for ix, table_joined_row in table_joined_df.iterrows():
-            log_task_id = table_joined_row.log_task_id
-            if table_joined_row.subject_id and table_joined_row.date_times:
-                # build notes filename and path as per convention
-                session_id = table_joined_row.subject_id+'_'+str(table_joined_row.date_times[0].date())
-                notes_fname = session_id+'-'+table_joined_row.stimulus_id+'-notes.txt'
-                notes_path = op.join(session_id, notes_fname)
-                cols = ['log_task_id', 'task_notes_file']
-                vals = [(log_task_id, notes_path)]
-                # and if that path exists - inser it into database table
-                if op.isfile(op.join(data_dir, notes_path)):
-                    table_log_task.insert_rows(vals, cols, on_conflict='update')
-                    print(vals)
-                
-                # adding outcomes and results files
-                if 'DSC' in table_joined_row.stimulus_id:
-                    results = table_joined_row.subject_id+'_'+str(table_joined_row.date_times[0].strftime('%Y-%m-%d_%Hh-%Mm-%Ss'))+'_DSC_results.csv'
-                    outcomes = table_joined_row.subject_id+'_'+str(table_joined_row.date_times[0].strftime('%Y-%m-%d_%Hh-%Mm-%Ss'))+'_DSC_outcomes.csv'
-                    field = [op.join(session_id, results), op.join(session_id, outcomes)]
-                    cols = ['log_task_id', 'task_output_files']
-                    vals = [(log_task_id, field)]
-                    if op.isfile(op.join(data_dir, field[0])) and op.isfile(op.join(data_dir, field[1])):
+    """
+    db_args = dict(
+        database = db_name,
+        user = db_user,
+        password = db_password
+    )
+
+    ssh_args = dict(
+            ssh_address_or_host='neurodoor.nmr.mgh.harvard.edu',
+            ssh_username='sp1022',
+            ssh_pkey='~/.ssh/id_rsa',
+            remote_bind_address=('192.168.100.1', 5432),
+            local_bind_address=('localhost', 6543),
+            allow_agent=False
+    )
+
+    data_dir = '/autofs/nas/neurobooth/data/'
+
+    with SSHTunnelForwarder(**ssh_args) as tunnel:
+        with psycopg2.connect(port=tunnel.local_bind_port,
+                              host=tunnel.local_bind_host, **db_args) as conn:
+            # build table dataframes
+            table_log_task = Table('log_task', conn)
+            table_task = Table('nb_task', conn)
+
+            log_task_df = table_log_task.query()
+            log_task_df.reset_index(inplace=True)
+
+            task_df = table_task.query()
+            task_df.reset_index(inplace=True)
+
+            # merging tables to get task spellings that are used for notes filenames
+            table_joined_df = pd.merge(log_task_df, task_df, on=['task_id'], how='left')
+            # for each row in table
+            for ix, table_joined_row in table_joined_df.iterrows():
+                log_task_id = table_joined_row.log_task_id
+                if table_joined_row.subject_id and table_joined_row.date_times:
+                    # build notes filename and path as per convention
+                    session_id = table_joined_row.subject_id+'_'+str(table_joined_row.date_times[0].date())
+                    notes_fname = session_id+'-'+table_joined_row.stimulus_id+'-notes.txt'
+                    notes_path = op.join(session_id, notes_fname)
+                    cols = ['log_task_id', 'task_notes_file']
+                    vals = [(log_task_id, notes_path)]
+                    # and if that path exists - inser it into database table
+                    if op.isfile(op.join(data_dir, notes_path)):
                         table_log_task.insert_rows(vals, cols, on_conflict='update')
                         print(vals)
-                elif 'MOT' in table_joined_row.stimulus_id:
-                    results = table_joined_row.subject_id+'_'+str(table_joined_row.date_times[0].strftime('%Y-%m-%d_%Hh-%Mm-%Ss'))+'_MOT_results.csv'
-                    outcomes = table_joined_row.subject_id+'_'+str(table_joined_row.date_times[0].strftime('%Y-%m-%d_%Hh-%Mm-%Ss'))+'_MOT_outcomes.csv'
-                    field = [op.join(session_id, results), op.join(session_id, outcomes)]
-                    cols = ['log_task_id', 'task_output_files']
-                    vals = [(log_task_id, field)]
-                    if op.isfile(op.join(data_dir, field[0])) and op.isfile(op.join(data_dir, field[1])):
-                        table_log_task.insert_rows(vals, cols, on_conflict='update')
-                        print(vals)
+
+                    # adding outcomes and results files
+                    if 'DSC' in table_joined_row.stimulus_id:
+                        results = table_joined_row.subject_id+'_'+str(table_joined_row.date_times[0].strftime('%Y-%m-%d_%Hh-%Mm-%Ss'))+'_DSC_results.csv'
+                        outcomes = table_joined_row.subject_id+'_'+str(table_joined_row.date_times[0].strftime('%Y-%m-%d_%Hh-%Mm-%Ss'))+'_DSC_outcomes.csv'
+                        field = [op.join(session_id, results), op.join(session_id, outcomes)]
+                        cols = ['log_task_id', 'task_output_files']
+                        vals = [(log_task_id, field)]
+                        if op.isfile(op.join(data_dir, field[0])) and op.isfile(op.join(data_dir, field[1])):
+                            table_log_task.insert_rows(vals, cols, on_conflict='update')
+                            print(vals)
+                    elif 'MOT' in table_joined_row.stimulus_id:
+                        results = table_joined_row.subject_id+'_'+str(table_joined_row.date_times[0].strftime('%Y-%m-%d_%Hh-%Mm-%Ss'))+'_MOT_results.csv'
+                        outcomes = table_joined_row.subject_id+'_'+str(table_joined_row.date_times[0].strftime('%Y-%m-%d_%Hh-%Mm-%Ss'))+'_MOT_outcomes.csv'
+                        field = [op.join(session_id, results), op.join(session_id, outcomes)]
+                        cols = ['log_task_id', 'task_output_files']
+                        vals = [(log_task_id, field)]
+                        if op.isfile(op.join(data_dir, field[0])) and op.isfile(op.join(data_dir, field[1])):
+                            table_log_task.insert_rows(vals, cols, on_conflict='update')
+                            print(vals)

--- a/scripts/populate_rcnotes_in_log_task.py
+++ b/scripts/populate_rcnotes_in_log_task.py
@@ -17,21 +17,15 @@ from sshtunnel import SSHTunnelForwarder
 from neurobooth_terra import Table
 
 
-def main(db_name: str, db_user: str, db_password) -> None:
+def main(db_args: Dict) -> None:
     """
     Populates RC notes in log_task table
-    :param db_name str  The name of the database
-    :param db_user str  The database username
-    :param db_password  The database user's password
+    params:
+        db_args Dict  The database credentials
 
     :returns: None
 
     """
-    db_args = dict(
-        database = db_name,
-        user = db_user,
-        password = db_password
-    )
 
     ssh_args = dict(
             ssh_address_or_host='neurodoor.nmr.mgh.harvard.edu',
@@ -93,3 +87,11 @@ def main(db_name: str, db_user: str, db_password) -> None:
                         if op.isfile(op.join(data_dir, field[0])) and op.isfile(op.join(data_dir, field[1])):
                             table_log_task.insert_rows(vals, cols, on_conflict='update')
                             print(vals)
+
+
+if __name__ == "__main__":
+
+    import credential_reader as reader
+    credentials = reader.read_db_secrets()
+    print (credentials)
+    main(credentials)

--- a/scripts/populate_rcnotes_in_log_task.py
+++ b/scripts/populate_rcnotes_in_log_task.py
@@ -93,5 +93,4 @@ if __name__ == "__main__":
 
     import credential_reader as reader
     credentials = reader.read_db_secrets()
-    print (credentials)
     main(credentials)


### PR DESCRIPTION
Removed hard-coded database credentials from files

Database credentials are now read from a file. See examples/dotdb_secrets.txt for an example credential file. 

Credential reading is localized in module scripts/credential_reader.  This script expects the credential file to be located in the scripts folder and named ".db_secrets.txt".  The gitignore file was updated to ignore files with this name.  The credentials file name and/or path can be modified by overriding the default value in the function credential_reader::read_db_secrets() (for every calling function) or by modifying the default value in credential_reader.
