### PR TITLE
Testing db secrets config rework

### DIFF
--- a/scripts/add_session_prefix_to_log_sensor_file.py
+++ b/scripts/add_session_prefix_to_log_sensor_file.py
@@ -46,11 +46,7 @@ def add_prefix_to_all(files):
 
 
 with SSHTunnelForwarder(**ssh_args) as tunnel:
-    with psycopg2.connect(
-            port=tunnel.local_bind_port,
-            host=tunnel.local_bind_host,
-            **db_args
-    ) as conn:
+    with psycopg2.connect(**db_args) as conn:
         db_table = Table(table_id, conn)
         df = db_table.query(where=where)
 

--- a/scripts/add_session_prefix_trailing_slash_to_log_file.py
+++ b/scripts/add_session_prefix_trailing_slash_to_log_file.py
@@ -5,11 +5,10 @@
 # to fnames
 
 import psycopg2
-
+import pandas as pd
 from sshtunnel import SSHTunnelForwarder
 from neurobooth_terra import Table
 import credential_reader as reader
-import os
 
 ssh_args = dict(
         ssh_address_or_host='neurodoor.nmr.mgh.harvard.edu',
@@ -30,8 +29,7 @@ table_id = 'log_file'
 where = f"src_dirname is not null"
 
 with SSHTunnelForwarder(**ssh_args) as tunnel:
-    with psycopg2.connect(port=tunnel.local_bind_port,
-                          host=tunnel.local_bind_host, **db_args) as conn:
+    with psycopg2.connect(**db_args) as conn:
         
         db_table = Table(table_id, conn)
         df = pd.DataFrame()

--- a/scripts/dataflow_copy.py
+++ b/scripts/dataflow_copy.py
@@ -89,8 +89,7 @@ if 'old' in sessions:
 
 # Copying data
 with OptionalSSHTunnelForwarder(**ssh_args) as tunnel:
-    with psycopg2.connect(port=tunnel.local_bind_port,
-                          host=tunnel.local_bind_host, **db_args) as conn:
+    with psycopg2.connect(**db_args) as conn:
 
         sensor_file_table = Table('log_sensor_file', conn)
         db_table = Table(table_id, conn)

--- a/scripts/dataflow_delete.py
+++ b/scripts/dataflow_delete.py
@@ -42,8 +42,7 @@ else:
     copied_older_than = copied_older_than_days * num_secs_in_a_day # seconds
 
 with OptionalSSHTunnelForwarder(**ssh_args) as tunnel:
-    with psycopg2.connect(port=tunnel.local_bind_port,
-                          host=tunnel.local_bind_host, **db_args) as conn:
+    with psycopg2.connect(**db_args) as conn:
 
         db_table = Table(table_id, conn)
 

--- a/scripts/dataflow_write_file_info.py
+++ b/scripts/dataflow_write_file_info.py
@@ -51,8 +51,7 @@ if 'old' in sessions:
     sessions.remove('old')
 
 with OptionalSSHTunnelForwarder(**ssh_args) as tunnel:
-    with psycopg2.connect(port=tunnel.local_bind_port,
-                          host=tunnel.local_bind_host, **db_args) as conn:
+    with psycopg2.connect(**db_args) as conn:
 
         if do_create_table:
             # drop old log_file_copy table

--- a/scripts/populate_rcnotes_in_log_task.py
+++ b/scripts/populate_rcnotes_in_log_task.py
@@ -39,8 +39,7 @@ def main(db_args: Dict) -> None:
     data_dir = '/autofs/nas/neurobooth/data/'
 
     with SSHTunnelForwarder(**ssh_args) as tunnel:
-        with psycopg2.connect(port=tunnel.local_bind_port,
-                              host=tunnel.local_bind_host, **db_args) as conn:
+        with psycopg2.connect(**db_args) as conn:
             # build table dataframes
             table_log_task = Table('log_task', conn)
             table_task = Table('nb_task', conn)

--- a/scripts/redcap_metadata_to_postgres.py
+++ b/scripts/redcap_metadata_to_postgres.py
@@ -187,11 +187,7 @@ rows_metadata, cols_metadata = dataframe_to_tuple(
 )
 
 with OptionalSSHTunnelForwarder(**ssh_args) as tunnel:
-    with psycopg2.connect(
-            port=tunnel.local_bind_port,
-            host=tunnel.local_bind_host,
-            **db_args
-    ) as conn:
+    with psycopg2.connect(**db_args) as conn:
 
         # Drop views first, as they may depend on the below tables
         drop_views(conn, verbose=True)

--- a/scripts/redcap_subject_to_postgres.py
+++ b/scripts/redcap_subject_to_postgres.py
@@ -41,8 +41,7 @@ rows_subject, cols_subject = dataframe_to_tuple(
                 'birthplace'])
 
 with OptionalSSHTunnelForwarder(**ssh_args) as tunnel:
-    with psycopg2.connect(port=tunnel.local_bind_port,
-                          host=tunnel.local_bind_host, **db_args) as conn:
+    with psycopg2.connect(**db_args) as conn:
 
         table_subject = Table('subject', conn)
         rename_subject_ids(table_subject, redcap_df)

--- a/scripts/update_missing_sessions.py
+++ b/scripts/update_missing_sessions.py
@@ -13,8 +13,7 @@ def sanitize_date(s):
 
 
 with OptionalSSHTunnelForwarder(**ssh_args) as tunnel:
-    with psycopg2.connect(port=tunnel.local_bind_port,
-                          host=tunnel.local_bind_host, **db_args) as conn:
+    with psycopg2.connect(**db_args) as conn:
 
         table_task = Table('log_task', conn)
         table_session = Table('log_session', conn)


### PR DESCRIPTION
This branch was for testing .db.secrets changes made by Larry. It was found that **ssh_args and **db_args were both passing the host argument to psycopg2 connect. We only need **db_args to connect to database now. Thus redundant host and port arguments from a bunch of files are removed in this branch.