### PR TITLE
Indicator column name and error handling

### DIFF
--- a/neurobooth_terra/redcap.py
+++ b/neurobooth_terra/redcap.py
@@ -357,12 +357,11 @@ def dataframe_to_tuple(df, df_columns, fixed_columns=None,
                 if col.startswith(indicator_column+'___'):
                     mapping[col] = col.split('___')[1]
             except:
-                error_text = f'Could not split column: {col} for indicator column: {indicator_column}\n \
-                                Is the combine-checkbox-option-into-single-column \
-                                under Redcap survey unchecked??'
-                raise IndicatorColumnError(error_text)
+                raise IndicatorColumnError('Could not split column: {col} for indicator column: {indicator_column}')
         if len(mapping) == 0:
-            raise ValueError(f'No column found starting with {indicator_column}')
+            error_text = f'Please confirm that the combine-checkbox-option-into-single-column' \
+                            'under Redcap survey is unchecked.\n'
+            raise ValueError(f'No column found starting with {indicator_column}\n{error_text}')
         df = combine_indicator_columns(df, mapping, indicator_column)
 
     rows = list()

--- a/neurobooth_terra/redcap.py
+++ b/neurobooth_terra/redcap.py
@@ -344,7 +344,7 @@ def dataframe_to_tuple(df, df_columns, fixed_columns=None,
     for indicator_column in indicator_columns:
         mapping = dict()  # {race___1: 1, race___2: 2}
         for col in df.columns:
-            if col.startswith(indicator_column):
+            if col.startswith(indicator_column+'___'):
                 mapping[col] = col.split('___')[1]
         if len(mapping) == 0:
             raise ValueError(f'No column found starting with {indicator_column}')


### PR DESCRIPTION
From @sid4py in Slack:

I've been working with Anna to iron a couple of things with Redcap:

- We have a category called Indicator Columns that are checkbox fields where multiple values can be selected, for example 'primary_diagnosis' - people can have multiple primary_diagnosis. Because of the logic in the code, there couldn't be other columns which start with the word 'primary_diagnosis' - which threw a bug because RCs added columns such as 'primary_diagnosis_certainty' for example.
- We have had issues with indicator_columns but every time have to go into code to debug what is happening because error output isn't informative. I added exception handling so when things go wrong we know exactly which indicator column is failing and where, and also partially why.

Because this code change is at the package level - whenever the PR is approved the roll out to production will be a reinstall of the package in mamba environment and not a simple pull of main branch. As usual I tested that all changes work and database state is fine.
