### PR TITLE
Skip orphan files from incomplete tasks in copy_files

### DIFF
--- a/neurobooth_terra/dataflow.py
+++ b/neurobooth_terra/dataflow.py
@@ -204,14 +204,26 @@ def copy_files(src_dir, dest_dir, db_table, sensor_file_table):
                 date_copied = this_out.split(' ')[-2]
                 time_verified = this_out.split(' ')[-1]
             
-            # query log_sensor_file table for this specific file
-            df = sensor_file_table.query(
-                where=f"sensor_file_path @> ARRAY['{fname}']").reset_index()
+            # Query log_sensor_file JOINed with log_task. Incomplete tasks
+            # (cancelled or crashed before _perform_task completed) have
+            # log_sensor_file rows written by ACQ at device-start time but
+            # log_task.task_id is NULL. Skip those so we don't transfer
+            # orphaned files.
+            cursor = sensor_file_table.conn.cursor()
+            cursor.execute(
+                """
+                SELECT lsf.log_sensor_file_id
+                FROM log_sensor_file lsf
+                JOIN log_task lt ON lsf.log_task_id = lt.log_task_id
+                WHERE lsf.sensor_file_path @> ARRAY[%s]
+                  AND lt.task_id IS NOT NULL
+                """,
+                (fname,),
+            )
+            rows = cursor.fetchall()
 
-            # TODO: If query returns empty, check the log_task table for txt/csv file
-
-            if len(df.log_sensor_file_id) > 0:
-                log_sensor_file_id = df.log_sensor_file_id[0]
+            if rows:
+                log_sensor_file_id = rows[0][0]
             else:
                 # files with these extensions are not tracked yet
                 untracked_extensions = ['xdf', 'txt', 'csv', 'jittered', 'asc', 'log']

--- a/neurobooth_terra/dataflow.py
+++ b/neurobooth_terra/dataflow.py
@@ -204,26 +204,26 @@ def copy_files(src_dir, dest_dir, db_table, sensor_file_table):
                 date_copied = this_out.split(' ')[-2]
                 time_verified = this_out.split(' ')[-1]
             
-            # Query log_sensor_file JOINed with log_task. Incomplete tasks
-            # (cancelled or crashed before _perform_task completed) have
-            # log_sensor_file rows written by ACQ at device-start time but
-            # log_task.task_id is NULL. Skip those so we don't transfer
-            # orphaned files.
-            cursor = sensor_file_table.conn.cursor()
-            cursor.execute(
-                """
-                SELECT lsf.log_sensor_file_id
-                FROM log_sensor_file lsf
-                JOIN log_task lt ON lsf.log_task_id = lt.log_task_id
-                WHERE lsf.sensor_file_path @> ARRAY[%s]
-                  AND lt.task_id IS NOT NULL
-                """,
-                (fname,),
-            )
-            rows = cursor.fetchall()
+            # Query log_sensor_file for this file, excluding rows whose
+            # parent log_task is incomplete (cancelled or crashed before
+            # _perform_task completed — neurobooth-os writes log_sensor_file
+            # rows at device-start time, so orphans exist with log_task.task_id
+            # IS NULL). The subquery piggybacks on Table.query()'s WHERE
+            # clause so we don't have to reach past the Table wrapper.
+            #
+            # NOTE: fname is interpolated into SQL via f-string here, matching
+            # the pre-existing pattern in this function. This is only safe
+            # because fname comes from rsync's controlled output over our own
+            # session directories. Do not adopt this pattern for user input.
+            df = sensor_file_table.query(
+                where=(f"sensor_file_path @> ARRAY['{fname}'] "
+                       f"AND log_task_id IN "
+                       f"(SELECT log_task_id FROM log_task "
+                       f"WHERE task_id IS NOT NULL)")
+            ).reset_index()
 
-            if rows:
-                log_sensor_file_id = rows[0][0]
+            if len(df.log_sensor_file_id) > 0:
+                log_sensor_file_id = df.log_sensor_file_id[0]
             else:
                 # files with these extensions are not tracked yet
                 untracked_extensions = ['xdf', 'txt', 'csv', 'jittered', 'asc', 'log']


### PR DESCRIPTION
Paired with neurobooth/neurobooth-os#686.

## Summary

neurobooth-os now registers sensor files in `log_sensor_file` at device-start time rather than during XDF post-processing. Tasks that were cancelled or crashed before completing have `log_sensor_file` rows but their `log_task` row has `task_id IS NULL` — those files shouldn't be transferred.

`copy_files` in `neurobooth_terra/dataflow.py` now JOINs `log_task` in the per-file lookup and filters on `task_id IS NOT NULL`. Files from completed tasks are transferred as before.

## Behavior

| Scenario | `log_task.task_id` | `log_sensor_file` | Copy action |
|---|---|---|---|
| Normal completion | set | yes, timing filled | transfer |
| User abort ('q') | set | yes, timing filled | transfer |
| Cancel before _perform_task | NULL | yes, no timing | **skip** |
| Crash before _perform_task | NULL | yes, no timing | **skip** |
| Bug: entry never created | -- | missing | **warn** (canary) |

The "log_sensor_file_id not found" warning is preserved for files with no row at all — that way genuine bugs still surface.

## Deploy order

This PR must be deployed **after** neurobooth/neurobooth-os#686. Before that PR is deployed, cancelled-task files never made it into `log_sensor_file` at all, so the filter here has nothing to exclude (and the old "not found" warnings continue as today).

## Test plan
- [ ] Verify `conn` is exposed on `sensor_file_table` (neurobooth_terra Table)
- [ ] Run `copy_files` against a session with a known cancelled task — no "not found" warning, no transfer
- [ ] Run against a session with only completed tasks — transfers as before